### PR TITLE
Remove deprecated method calls

### DIFF
--- a/src/main/java/org/primefaces/extensions/ckeditor/ResourceModifier.java
+++ b/src/main/java/org/primefaces/extensions/ckeditor/ResourceModifier.java
@@ -17,6 +17,7 @@ package org.primefaces.extensions.ckeditor;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,7 +64,7 @@ public class ResourceModifier {
 
                 System.err.println("## Modify file '" + resourceToModify.getName() + "'");
 
-                String fileContent = FileUtils.readFileToString(resourceToModify);
+                String fileContent = FileUtils.readFileToString(resourceToModify, Charset.defaultCharset());
                 final List<File> allSkinResources = getResourcesList(skinDirectory);
 
                 // loop all possible image references
@@ -99,7 +100,7 @@ public class ResourceModifier {
                 fileContent = fileContent.replaceAll("url\\(icons_hidpi.png\\?t=GAGE",
                             "url\\(\"#{resource['primefaces-extensions:" + relativeSkinPath + "/icons_hidpi.png']}&t=GAGE\"");
 
-                FileUtils.writeStringToFile(resourceToModify, fileContent);
+                FileUtils.writeStringToFile(resourceToModify, fileContent,Charset.defaultCharset());
             }
 
             String fileContent = "";
@@ -108,15 +109,15 @@ public class ResourceModifier {
             // modify smileys plugin to load the smileys via CKEditor.getUrl
             file = new File(PROJECT_DIRECTORY
                         + "/src/main/resources/META-INF/resources/primefaces-extensions/ckeditor/plugins/smiley/dialogs/smiley.js");
-            fileContent = FileUtils.readFileToString(file).replaceAll(
+            fileContent = FileUtils.readFileToString(file,Charset.defaultCharset()).replaceAll(
                         "CKEDITOR.tools.htmlEncode\\(e\\.smiley_path\\+h\\[a\\]\\)",
                         "CKEDITOR.tools.htmlEncode\\(CKEDITOR.getUrl\\(e\\.smiley_path\\+h\\[a\\]\\)\\)");
-            FileUtils.writeStringToFile(file, fileContent);
+            FileUtils.writeStringToFile(file, fileContent,Charset.defaultCharset());
         }
 
         // read the main JS file
         final File file = new File(resourcesDirectory + "ckeditor/ckeditor.js");
-        String fileContent = FileUtils.readFileToString(file);
+        String fileContent = FileUtils.readFileToString(file,Charset.defaultCharset());
 
         // modify copyFormatting plugin to load copyformatting.css via CKEditor.getUrl
         fileContent = fileContent.replaceAll(
@@ -134,7 +135,7 @@ public class ResourceModifier {
                     "CKEDITOR.getUrl(this.path\\+\"skins/\"\\+CKEDITOR.skin.name\\+\"/wsc.css\")");
 
         // write file back out
-        FileUtils.writeStringToFile(file, fileContent);
+        FileUtils.writeStringToFile(file, fileContent,Charset.defaultCharset());
     }
 
     private static List<File> getResourcesList(final File file) {


### PR DESCRIPTION
```java
/**
     * Writes a String to a file creating the file if it does not exist using the default encoding for the VM.
     *
     * @param file the file to write
     * @param data the content to write to the file
     * @throws IOException in case of an I/O error
     * @deprecated 2.5 use {@link #writeStringToFile(File, String, Charset)} instead (and specify the appropriate encoding)
     */
    @Deprecated
    public static void writeStringToFile(final File file, final String data) throws IOException {
        writeStringToFile(file, data, Charset.defaultCharset(), false);
    }
```

Please merge it first, as I would need to make some more changes later on.